### PR TITLE
Simplify blackBox creation from browsing context

### DIFF
--- a/driftwood.js
+++ b/driftwood.js
@@ -56,10 +56,10 @@ var Driftwood = new function() {
         "message": error || "",
 
         // Request
-        "url": window.location.toString(),
+        "url": location.href,
         "language":"javascript",
         "custom_data": {
-          "hostname": window.location.hostname,
+          "hostname": location.hostname,
           "user_agent": navigator.userAgent || "",
           "referrer": document.referrer || "",
           "cookies": document.cookie || "",


### PR DESCRIPTION
- Omit "window". Location is its own global, always has been. (Just like document.)
- Use location.href instead of location.toString. (Faster and more conventional.)
